### PR TITLE
[rayscope] add initial stub for ray top and object command and local setup steps 

### DIFF
--- a/python/ray/scripts/scripts.py
+++ b/python/ray/scripts/scripts.py
@@ -269,7 +269,9 @@ def top(address: str, refresh: float, show: str, limit: int):
                 out.append(d())
             else:
                 d2 = getattr(it, "dict", None)
-                out.append(d2() if callable(d2) else getattr(it, "__dict__", {}) or dict(it))
+                out.append(
+                    d2() if callable(d2) else getattr(it, "__dict__", {}) or dict(it)
+                )
         return out
 
     import sys
@@ -298,15 +300,20 @@ def top(address: str, refresh: float, show: str, limit: int):
                 )
 
             node_dicts = _to_dicts(nodes)
-            live_nodes = sum(1 for n in node_dicts if str(n.get("state", "")).upper() == "ALIVE")
+            live_nodes = sum(
+                1 for n in node_dicts if str(n.get("state", "")).upper() == "ALIVE"
+            )
 
             # Clear screen and print a compact summary.
             sys.stdout.write("\x1b[2J\x1b[H")
             print("ray top (experimental) — Ctrl+C to exit")
-            print(f"Nodes: {len(node_dicts)} (live: {live_nodes})  Tasks: {len(tasks)}  Actors: {len(actors)}")
+            print(
+                f"Nodes: {len(node_dicts)} (live: {live_nodes})  Tasks: {len(tasks)}  Actors: {len(actors)}"
+            )
             _time.sleep(max(0.1, float(refresh)))
     except KeyboardInterrupt:
         return
+
 
 @cli.command()
 @click.option(

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -598,6 +598,80 @@ def summary_state_cli_group(ctx):
     pass
 
 
+# Experimental: `ray object ls` as a convenience alias to `ray list objects`
+@click.group("object")
+@click.pass_context
+def object_state_cli_group(ctx):
+    """Object tooling (experimental)."""
+    pass
+
+
+@object_state_cli_group.command(name="ls")
+@click.option("--format", default="default", type=click.Choice(_get_available_formats()))
+@click.option(
+    "-f",
+    "--filter",
+    help=(
+        "A key, predicate, and value to filter the result. "
+        "E.g., --filter 'key=value' or --filter 'key!=value'. "
+        "You can specify multiple --filter options. Predicates are ANDed. "
+        "String filter values are case-insensitive."
+    ),
+    multiple=True,
+)
+@click.option(
+    "--limit",
+    default=DEFAULT_LIMIT,
+    type=int,
+    help=("Maximum number of entries to return. 100 by default."),
+)
+@click.option(
+    "--detail",
+    help=(
+        "If the flag is set, the output will contain data in more details. "
+        "Note that the API could query more sources to obtain information in a greater detail."
+    ),
+    is_flag=True,
+    default=False,
+)
+@timeout_option
+@address_option
+def object_ls(
+    format: str,
+    filter: List[str],
+    limit: int,
+    detail: bool,
+    timeout: float,
+    address: str,
+):
+    resource = StateResource.OBJECTS
+    format = AvailableFormat(format)
+    client = StateApiClient(address=address)
+    filter = [_parse_filter(f) for f in filter]
+    options = ListApiOptions(limit=limit, timeout=timeout, filters=filter, detail=detail)
+    try:
+        data = client.list(
+            resource,
+            options=options,
+            raise_on_missing_output=False,
+            _explain=_should_explain(format),
+        )
+    except RayStateApiException as e:
+        raise click.UsageError(str(e))
+
+    if detail and format == AvailableFormat.DEFAULT:
+        format = AvailableFormat.YAML
+
+    print(
+        format_list_api_output(
+            state_data=data,
+            schema=resource_to_schema(resource),
+            format=format,
+            detail=detail,
+        )
+    )
+
+
 @summary_state_cli_group.command(name="tasks")
 @timeout_option
 @address_option

--- a/python/ray/util/state/state_cli.py
+++ b/python/ray/util/state/state_cli.py
@@ -607,7 +607,9 @@ def object_state_cli_group(ctx):
 
 
 @object_state_cli_group.command(name="ls")
-@click.option("--format", default="default", type=click.Choice(_get_available_formats()))
+@click.option(
+    "--format", default="default", type=click.Choice(_get_available_formats())
+)
 @click.option(
     "-f",
     "--filter",
@@ -648,7 +650,9 @@ def object_ls(
     format = AvailableFormat(format)
     client = StateApiClient(address=address)
     filter = [_parse_filter(f) for f in filter]
-    options = ListApiOptions(limit=limit, timeout=timeout, filters=filter, detail=detail)
+    options = ListApiOptions(
+        limit=limit, timeout=timeout, filters=filter, detail=detail
+    )
     try:
         data = client.list(
             resource,

--- a/rayscope.md
+++ b/rayscope.md
@@ -1,0 +1,154 @@
+## RayScope runbook (local smoke test)
+
+### Prerequisites
+
+- Activate the Ray-compatible conda env (provided):
+
+```bash
+conda activate rayenv
+```
+
+- Point Python to the in-repo Ray sources (we’ll run the CLI from this repo):
+
+```bash
+export PYTHONPATH=/Users/sagar/workspace/codope/ray/python:$PYTHONPATH
+```
+
+### Start a local cluster
+
+- Option A: via CLI (dashboard can auto-pick a free port with `--dashboard-port=0`)
+
+```bash
+python -m ray.scripts.scripts start --head --include-dashboard=True --num-cpus=4
+# If 8265 is occupied, add:
+# python -m ray.scripts.scripts start --head --include-dashboard=True --num-cpus=4 --dashboard-port=0
+```
+
+- Option B: in-process (quick test)
+
+```bash
+python - <<'PY'
+import ray
+ray.init()
+print("Ray is up:", ray.is_initialized())
+PY
+```
+
+- Verify the CLI entrypoint loads
+
+```bash
+python -m ray.scripts.scripts --help
+```
+
+### Run a small workload (tasks, actors, objects)
+
+Use a second terminal with the same environment:
+
+```bash
+conda activate rayenv
+export PYTHONPATH=/Users/sagar/workspace/codope/ray/python:$PYTHONPATH
+
+python - <<'PY'
+import time
+import numpy as np
+import ray
+
+# Tip: to record object callsites for richer object insights,
+# start Ray with RAY_record_ref_creation_sites=1 in the environment.
+
+ray.init(address="auto")
+
+@ray.remote
+def sleep_and_return(i, secs=0.5, size_mb=5):
+    time.sleep(secs)
+    # Create an array to store in the object store (~ size_mb)
+    arr = np.ones((size_mb * 250_000,), dtype=np.float32)
+    return i, arr
+
+@ray.remote
+class Counter:
+    def __init__(self):
+        self.n = 0
+    def incr(self, k=1):
+        self.n += k
+        time.sleep(0.2)
+        return self.n
+
+# Submit tasks
+# Smaller size to keep output readable; bump size_mb for larger objects
+refs = [sleep_and_return.remote(i, secs=0.2, size_mb=2) for i in range(20)]
+
+# Create an actor, call it a few times
+c = Counter.remote()
+actor_refs = [c.incr.remote() for _ in range(10)]
+
+print("First 5 task results:", ray.get(refs[:5]))
+print("Actor result sample:", ray.get(actor_refs[-1]))
+print("Workload submitted; leaving others in-flight for observability...")
+time.sleep(5)
+PY
+```
+
+### Smoke test the new CLI commands
+
+- Object listing (alias for the State API “list objects”)
+
+```bash
+python -m ray.scripts.scripts object ls --address=auto --limit 10 --format table
+
+# JSON output
+python -m ray.scripts.scripts object ls --address=auto --limit 10 --format json
+
+# Server-side filter examples
+python -m ray.scripts.scripts object ls --address=auto --filter "ip=127.0.0.1" --limit 50 --format table
+```
+
+- Lightweight terminal “top” snapshot (experimental)
+
+```bash
+python -m ray.scripts.scripts top --address=auto --refresh 1.0 --show both
+# Press Ctrl+C to exit
+```
+
+- Baseline state snapshots (useful for comparison)
+
+```bash
+python -m ray.scripts.scripts list tasks  --address=auto --limit 20 --format table
+python -m ray.scripts.scripts list actors --address=auto --limit 20 --format table
+python -m ray.scripts.scripts list objects --address=auto --limit 20 --format table
+```
+
+### Cleanup
+
+```bash
+python -m ray.scripts.scripts stop
+# If you used in-process init, exiting the process is enough (ray.shutdown() optional)
+```
+
+### Troubleshooting
+
+- CLI cannot find the cluster:
+
+```bash
+# Ensure a cluster is running and pass an address
+python -m ray.scripts.scripts status --address=auto
+```
+
+- Dashboard port 8265 is in use:
+
+```bash
+python -m ray.scripts.scripts start --head --dashboard-port=0
+```
+
+- Imports fail or CLI not found:
+
+```bash
+conda activate rayenv
+export PYTHONPATH=/Users/sagar/workspace/codope/ray/python:$PYTHONPATH
+```
+
+- Record object callsites for richer object info:
+
+Set `RAY_record_ref_creation_sites=1` in the environment for both the cluster and client processes before starting Ray.
+
+


### PR DESCRIPTION
- Added minimal ray top inside existing python/ray/scripts/scripts.py with no new files:
  - Usage: `conda activate rayenv; export PYTHONPATH=/Users/sagar/workspace/codope/ray/python:$PYTHONPATH`
  - Start cluster (or ray.init in another shell), then: `python -m ray.scripts.scripts top --address=auto --refresh 1.0 --show both`
  - It displays live counts of nodes (and live subset), tasks, and actors, refreshing until Ctrl+C.

- Implementation details
  - Reuses `StateApiClient` and `ListApiOptions` to query NODES, TASKS, ACTORS.
  - Clears the terminal and prints a compact summary per interval.
  - Flags: --address, --refresh, --show tasks|actors|both, --limit.

- Confirmed in `rayenv`
  - `python -m ray.scripts.scripts --help` shows `object` and `top` now.
  - Can point to an existing local Ray instance with `--address=auto`.